### PR TITLE
Add support for vanilla v2.1+

### DIFF
--- a/BottigiDiscord/BotMain.cs
+++ b/BottigiDiscord/BotMain.cs
@@ -4,7 +4,6 @@ using Discord;
 using Discord.WebSocket;
 using ReplayFile;
 using ReplayViewer;
-using ReplayViewer.ReplayDrawers;
 
 namespace BottigiDiscord;
 
@@ -28,13 +27,13 @@ public static class BotMain
         {4, "Purple"},
     };
 
-    private static readonly Dictionary<byte, string> CharacterNames = new()
+    private static readonly Dictionary<long, string> CharacterNames = new()
     {
-        {0, "\u001b[1;31mM\u001b[0;0m"},
-        {1, "\u001b[1;32mL\u001b[0;0m"},
-        {255, "\u001b[1;30m-\u001b[0;0m"},
+        {532063855470386108, "\u001b[1;31mM\u001b[0;0m"}, // Mario
+        {485289843648077326, "\u001b[1;32mL\u001b[0;0m"}, // Luigi
     };
-    
+    private static readonly string FallbackCharacterName = "\u001b[1;30m-\u001b[0;0m";
+
     private static readonly DiscordSocketConfig Intents = new()
     {
         GatewayIntents = GatewayIntents.AllUnprivileged | GatewayIntents.MessageContent
@@ -149,7 +148,7 @@ public static class BotMain
         var playersString = new StringBuilder();
         foreach (var player in replay.Players.OrderByDescending(info => info.FinalObjectiveCount))
         {
-            playersString.Append($"{CharacterNames.GetValueOrDefault(player.Character, CharacterNames[255])} ");
+            playersString.Append($"{CharacterNames.GetValueOrDefault(player.Character, FallbackCharacterName)} ");
             
             if (replay.Rules.IsTeamsEnabled && player.Team < TeamColourCodes.Count) playersString.Append($"{TeamColourCodes[player.Team]}");
             playersString.Append(player.Username.PadRight(21));
@@ -170,7 +169,7 @@ public static class BotMain
         var iconPath = StageIconGetter.GetIconPath(replay.Rules.StageName);
         var iconFileName = Path.GetFileName(iconPath);
         var description = new StringBuilder();
-        if (replay.Format?.ModName != "Vanilla")
+        if (replay.Format is { IsVanilla: false })
             description.AppendLine($"This replay is from mod \"*{replay.Format?.ModName}*\".");
         // description.Append($"**{replay.Rules.GamemodeName}** match on **{replay.Rules.StageName}**.");
 

--- a/ReplayFile/BinaryReplayFile.cs
+++ b/ReplayFile/BinaryReplayFile.cs
@@ -199,8 +199,9 @@ public record struct ReplayPlayerInfo
                 Username = reader.ReadString(),
                 FinalObjectiveCount = reader.ReadInt32(),
                 Team = reader.ReadByte(),
-                Character = Characters[reader.ReadByte()],
             };
+            byte characterIndex = reader.ReadByte();
+            result.Character = (characterIndex < Characters.Length) ? Characters[characterIndex] : 0;
             reader.ReadInt32(); // Discard PlayerRef
         }
 

--- a/ReplayFile/BinaryReplayFile.cs
+++ b/ReplayFile/BinaryReplayFile.cs
@@ -5,7 +5,7 @@ namespace ReplayFile;
 
 public class BinaryReplayFile
 {
-    public const int SolutionVersion = 0;
+    public const int SolutionVersion = 1;
 
     public readonly ReplayFormat? Format;
     public readonly long FileSize;
@@ -35,7 +35,7 @@ public class BinaryReplayFile
             input.CopyTo(memInput);
             input.Dispose();
         }
-        using var reader = new BinaryReader(memInput.Length > 0 ? memInput : input, Encoding.ASCII);
+        using var reader = new BinaryReader(memInput.Length > 0 ? memInput : input, Encoding.UTF8);
         FileSize = reader.BaseStream.Length;
 
         try

--- a/ReplayFile/BinaryReplayFile.cs
+++ b/ReplayFile/BinaryReplayFile.cs
@@ -71,14 +71,7 @@ public class BinaryReplayFile
             Players = new ReplayPlayerInfo[reader.ReadByte()];
             for (var i = 0; i < Players.Length; i++)
             {
-                Players[i] = new ReplayPlayerInfo
-                {
-                    Username = reader.ReadString(),
-                    FinalObjectiveCount = reader.ReadInt32(),
-                    Team = reader.ReadByte(),
-                    Character = reader.ReadByte(),
-                };
-                reader.ReadInt32(); // Quantum Ref
+                Players[i] = ReplayPlayerInfo.Parse(reader, Version);
             }
             
             WinningTeam = reader.ReadSByte();
@@ -171,15 +164,46 @@ public struct GameRules
 
 public record struct ReplayPlayerInfo
 {
+    private static readonly long[] Characters = 
+    [
+        532063855470386108, // Mario
+        485289843648077326, // Luigi
+    ];
+
     public string Username;
     public int FinalObjectiveCount;
-    public byte Team, Character;
+    public byte Team;
+    public long Character;
 
     public bool Equals(ReplayPlayerInfo other) => Username == other.Username;
     public override int GetHashCode() => Username.GetHashCode();
-}
 
-public struct GameVersion
-{
-    public byte Major, Minor, Patch, Hotfix;
+    public static ReplayPlayerInfo Parse(BinaryReader reader, GameVersion version)
+    {
+        ReplayPlayerInfo result;
+        if (version >= new GameVersion(2, 1))
+        {
+            // Addon capable format- `Character` is an AssetGuid (long)
+            result = new ReplayPlayerInfo {
+                Username = reader.ReadString(),
+                FinalObjectiveCount = reader.ReadInt32(),
+                Team = reader.ReadByte(),
+                Character = reader.ReadInt64(),
+            };
+            reader.ReadInt32(); // Discard PlayerRef
+        }
+        else
+        {
+            // Old format- `Character` is single byte representing index
+            result = new ReplayPlayerInfo {
+                Username = reader.ReadString(),
+                FinalObjectiveCount = reader.ReadInt32(),
+                Team = reader.ReadByte(),
+                Character = Characters[reader.ReadByte()],
+            };
+            reader.ReadInt32(); // Discard PlayerRef
+        }
+
+        return result;
+    }
 }

--- a/ReplayFile/GameVersion.cs
+++ b/ReplayFile/GameVersion.cs
@@ -1,0 +1,118 @@
+﻿namespace ReplayFile;
+
+public struct GameVersion : IEquatable<GameVersion>, IComparable<GameVersion>
+{
+    public byte Major, Minor, Patch, Hotfix;
+
+    public GameVersion(byte major, byte minor, byte patch = 0, byte hotfix = 0) {
+        Major = major;
+        Minor = minor;
+        Patch = patch;
+        Hotfix = hotfix;
+    }
+
+    public readonly bool Equals(GameVersion other) {
+        return Major == other.Major && Minor == other.Minor && Patch == other.Patch && Hotfix == other.Hotfix;
+    }
+
+    public readonly bool EqualsIgnoreHotfix(GameVersion other) {
+        return Major == other.Major && Minor == other.Minor && Patch == other.Patch;
+    }
+
+    public readonly int CompareTo(GameVersion other) {
+        if (Major != other.Major) {
+            return Major - other.Major;
+        }
+        if (Minor != other.Minor) {
+            return Minor - other.Minor;
+        }
+        if (Patch != other.Patch) {
+            return Patch - other.Patch;
+        }
+        return Hotfix - other.Hotfix;
+    }
+
+    public static bool operator >(GameVersion x, GameVersion y) {
+        return x.CompareTo(y) > 0;
+    }
+
+    public static bool operator <(GameVersion x, GameVersion y) {
+        return x.CompareTo(y) < 0;
+    }
+
+    public static bool operator >=(GameVersion x, GameVersion y) {
+        return x.CompareTo(y) >= 0;
+    }
+
+    public static bool operator <=(GameVersion x, GameVersion y) {
+        return x.CompareTo(y) <= 0;
+    }
+
+    public override readonly string ToString() {
+        return $"{Major}.{Minor}.{Patch}.{Hotfix}";
+    }
+
+    public readonly string ToStringIgnoreHotfix() {
+        return $"{Major}.{Minor}.{Patch}";
+    }
+
+    public int GetHashCode(GameVersion obj) {
+        // https://stackoverflow.com/a/1646913/19635374
+        unchecked {
+            int hash = 17;
+            hash = hash * 31 + obj.Major.GetHashCode();
+            hash = hash * 31 + obj.Minor.GetHashCode();
+            hash = hash * 31 + obj.Patch.GetHashCode();
+            hash = hash * 31 + obj.Hotfix.GetHashCode();
+            return hash;
+        }
+    }
+
+    public readonly void Serialize(BinaryWriter writer)
+    {
+        writer.Write(Major);
+        writer.Write(Minor);
+        writer.Write(Patch);
+        writer.Write(Hotfix);
+    }
+
+    public static GameVersion Deserialize(BinaryReader reader)
+    {
+        return new GameVersion
+        {
+            Major = reader.ReadByte(),
+            Minor = reader.ReadByte(),
+            Patch = reader.ReadByte(),
+            Hotfix = reader.ReadByte(),
+        };
+    }
+
+    /*
+    public static GameVersion Parse(ReadOnlySpan<char> version) {
+        Span<byte> parsed = stackalloc byte[4];
+        if (version.StartsWith("v", StringComparison.InvariantCultureIgnoreCase)) {
+            version = version[1..];
+        }
+
+        for (int i = 0; i < parsed.Length; i++) {
+            int separator = version.IndexOf('.');
+            if (separator == -1) {
+                separator = version.Length;
+            }
+
+            byte.TryParse(version[..separator], out parsed[i]);
+            if (version.Length - separator <= 0) {
+                break;
+            }
+            version = version[(separator + 1)..];
+        }
+
+        return new GameVersion {
+            Major = parsed[0],
+            Minor = parsed[1],
+            Patch = parsed[2],
+            Hotfix = parsed[3],
+        };
+    }
+    */
+}

--- a/ReplayFile/GameVersion.cs
+++ b/ReplayFile/GameVersion.cs
@@ -1,15 +1,9 @@
 ﻿namespace ReplayFile;
 
-public struct GameVersion : IEquatable<GameVersion>, IComparable<GameVersion>
+public struct GameVersion(byte major, byte minor, byte patch = 0, byte hotfix = 0)
+    : IEquatable<GameVersion>, IComparable<GameVersion>
 {
-    public byte Major, Minor, Patch, Hotfix;
-
-    public GameVersion(byte major, byte minor, byte patch = 0, byte hotfix = 0) {
-        Major = major;
-        Minor = minor;
-        Patch = patch;
-        Hotfix = hotfix;
-    }
+    public byte Major = major, Minor = minor, Patch = patch, Hotfix = hotfix;
 
     public readonly bool Equals(GameVersion other) {
         return Major == other.Major && Minor == other.Minor && Patch == other.Patch && Hotfix == other.Hotfix;
@@ -48,71 +42,7 @@ public struct GameVersion : IEquatable<GameVersion>, IComparable<GameVersion>
         return x.CompareTo(y) <= 0;
     }
 
-    public override readonly string ToString() {
+    public readonly override string ToString() {
         return $"{Major}.{Minor}.{Patch}.{Hotfix}";
     }
-
-    public readonly string ToStringIgnoreHotfix() {
-        return $"{Major}.{Minor}.{Patch}";
-    }
-
-    public int GetHashCode(GameVersion obj) {
-        // https://stackoverflow.com/a/1646913/19635374
-        unchecked {
-            int hash = 17;
-            hash = hash * 31 + obj.Major.GetHashCode();
-            hash = hash * 31 + obj.Minor.GetHashCode();
-            hash = hash * 31 + obj.Patch.GetHashCode();
-            hash = hash * 31 + obj.Hotfix.GetHashCode();
-            return hash;
-        }
-    }
-
-    public readonly void Serialize(BinaryWriter writer)
-    {
-        writer.Write(Major);
-        writer.Write(Minor);
-        writer.Write(Patch);
-        writer.Write(Hotfix);
-    }
-
-    public static GameVersion Deserialize(BinaryReader reader)
-    {
-        return new GameVersion
-        {
-            Major = reader.ReadByte(),
-            Minor = reader.ReadByte(),
-            Patch = reader.ReadByte(),
-            Hotfix = reader.ReadByte(),
-        };
-    }
-
-    /*
-    public static GameVersion Parse(ReadOnlySpan<char> version) {
-        Span<byte> parsed = stackalloc byte[4];
-        if (version.StartsWith("v", StringComparison.InvariantCultureIgnoreCase)) {
-            version = version[1..];
-        }
-
-        for (int i = 0; i < parsed.Length; i++) {
-            int separator = version.IndexOf('.');
-            if (separator == -1) {
-                separator = version.Length;
-            }
-
-            byte.TryParse(version[..separator], out parsed[i]);
-            if (version.Length - separator <= 0) {
-                break;
-            }
-            version = version[(separator + 1)..];
-        }
-
-        return new GameVersion {
-            Major = parsed[0],
-            Minor = parsed[1],
-            Patch = parsed[2],
-            Hotfix = parsed[3],
-        };
-    }
-    */
 }

--- a/ReplayFile/ReplayModMapper.cs
+++ b/ReplayFile/ReplayModMapper.cs
@@ -9,6 +9,7 @@ public static class ReplayModMapper
             Header = "MvLO-RP",
             Extension = ".mvlreplay",
             ModName = "Vanilla",
+            IsVanilla = true,
         },
         new()
         {
@@ -22,6 +23,7 @@ public static class ReplayModMapper
 public record struct ReplayFormat
 {
     public string Header, Extension, ModName;
+    public bool IsVanilla;
 
     public bool Equals(ReplayFormat? other) => Header == other?.Header;
     public override int GetHashCode() => Header.GetHashCode();


### PR DESCRIPTION
Adds support for v2.1 by changing the `ReplayPlayerInfo.Character` from a byte index into a characters array to an AssetRef lookup